### PR TITLE
fixed eodr naming bug

### DIFF
--- a/geopathfinder/naming_conventions/eodr_naming.py
+++ b/geopathfinder/naming_conventions/eodr_naming.py
@@ -38,6 +38,7 @@ class EODRFilename(SmartFilename):
         ('id', {'len': 12}),
         ('dt_1', {'len': 15}),
         ('dt_2', {'len': 15}),
+        ('file_num', {}),
         ('band', {})
     ])
     pad = "-"
@@ -63,6 +64,8 @@ class EODRFilename(SmartFilename):
         fields_def_ext['dt_1']['encoder'] = lambda x: self.encode_datetime(x)
         fields_def_ext['dt_2']['decoder'] = lambda x: self.decode_datetime(x)
         fields_def_ext['dt_2']['encoder'] = lambda x: self.encode_datetime(x)
+        fields_def_ext['file_num']['decoder'] = lambda x: int(x)
+        fields_def_ext['file_num']['encoder'] = lambda x: str(x)
         fields_def_ext['band']['encoder'] = lambda x: str(x)
 
         fields_def_keys = list(fields_def_ext.keys())
@@ -81,7 +84,7 @@ class EODRFilename(SmartFilename):
         Parameters
         ----------
         filename_str : str
-            Filename without any paths (e.g., "123456------_20181220T232333_---------------_B5_34_aug.vrt").
+            Filename without any paths (e.g., "123456------_20181220T232333_---------------_2_B5_34_aug.vrt").
         convert: bool, optional
             If true, decoding is applied to parts of the filename, where such an operation is available (default is False).
 
@@ -93,10 +96,11 @@ class EODRFilename(SmartFilename):
 
         fn_parts = os.path.splitext(os.path.basename(filename_str))[0].split(EODRFilename.delimiter)
         fields_def_ext = copy.deepcopy(EODRFilename.fields_def)
-        fields_def_ext['band']['len'] = len(fn_parts[3])  # get length of the band in the filename
+        fields_def_ext['file_num']['len'] = len(fn_parts[3])
+        fields_def_ext['band']['len'] = len(fn_parts[4])  # get length of the band in the filename
         # if the filename consists of more than 4 parts, additional "dimensions" are added to the fields dictionary
-        if len(fn_parts) > 4:
-            for i, fn_part in enumerate(fn_parts[4:]):
+        if len(fn_parts) > 5:
+            for i, fn_part in enumerate(fn_parts[5:]):
                 key = 'd' + str(i + 1)
                 fields_def_ext[key] = {'len': len(fn_part)}
 

--- a/tests/test_eodr_naming.py
+++ b/tests/test_eodr_naming.py
@@ -30,16 +30,18 @@ class TestEODRFilename(unittest.TestCase):
         self.id_2 = "654321"
         self.dt_1 = datetime(2008, 1, 1, 12, 23, 33)
         self.dt_2 = datetime(2009, 2, 2, 22, 1, 1)
+        self.file_num = 2
 
-        fields_1 = {'id': self.id_1, 'dt_1': self.dt_1, 'band': 'B1'}
+        fields_1 = {'id': self.id_1, 'dt_1': self.dt_1, 'file_num': self.file_num, 'band': 'B1'}
 
         self.eodr_fn_1 = EODRFilename(fields_1, convert=True)
 
-        fields_2 = {'id': self.id_2, 'dt_1':  self.dt_1, 'dt_2': self.dt_2, 'band': 'B12', 'd1': '45'}
+        fields_2 = {'id': self.id_2, 'dt_1':  self.dt_1, 'dt_2': self.dt_2, 'file_num': self.file_num,
+                    'band': 'B12', 'd1': '45'}
 
         self.eodr_fn_2 = EODRFilename(fields_2, convert=True)
 
-        fn = '123456------_20181220T232333_---------------_B5_34_aug.vrt'
+        fn = '123456------_20181220T232333_---------------_544_B5_34_aug.vrt'
         self.eodr_fn_3 = EODRFilename.from_filename(fn, convert=True)
 
         self.eodr_fn_4 = EODRFilename.from_filename(fn)
@@ -49,7 +51,7 @@ class TestEODRFilename(unittest.TestCase):
         Test building SGRT file name.
 
         """
-        fn = ('123456------_20080101T122333_---------------_B1.vrt')
+        fn = ('123456------_20080101T122333_---------------_2_B1.vrt')
 
         self.assertEqual(str(self.eodr_fn_1), fn)
 
@@ -76,6 +78,7 @@ class TestEODRFilename(unittest.TestCase):
         self.assertEqual(self.eodr_fn_3['id'], '123456')
         self.assertEqual(self.eodr_fn_3['dt_1'], datetime(2018, 12, 20, 23, 23, 33))
         self.assertEqual(self.eodr_fn_3['dt_2'], None)
+        self.assertEqual(self.eodr_fn_3['file_num'], 544)
         self.assertEqual(self.eodr_fn_3['band'], 'B5')
         self.assertEqual(self.eodr_fn_3['d1'], '34')
         self.assertEqual(self.eodr_fn_3['d2'], 'aug')
@@ -85,6 +88,7 @@ class TestEODRFilename(unittest.TestCase):
         self.assertEqual(self.eodr_fn_4['id'], '123456')
         self.assertEqual(self.eodr_fn_4['dt_1'], '20181220T232333')
         self.assertEqual(self.eodr_fn_4['dt_2'], '')
+        self.assertEqual(self.eodr_fn_4['file_num'], '544')
         self.assertEqual(self.eodr_fn_4['band'], 'B5')
         self.assertEqual(self.eodr_fn_4['d1'], '34')
         self.assertEqual(self.eodr_fn_4['d2'], 'aug')
@@ -93,3 +97,5 @@ class TestEODRFilename(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+    #tester = TestEODRFilename()
+    #tester.setUp()


### PR DESCRIPTION
accidentally dropped 'file_num' for the EODR filenaming convention was added again to the main classes and tests (#11)